### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,4 +1,7 @@
 name: Restyled
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/laniksj.github.io/security/code-scanning/1](https://github.com/LanikSJ/laniksj.github.io/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating and managing pull requests.

The `permissions` block will be added at the top of the workflow, just below the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
