### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   Scan-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/laniksj.github.io/security/code-scanning/2](https://github.com/LanikSJ/laniksj.github.io/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, the `contents: read` permission is necessary for the `actions/checkout` step, and the `security-events: write` permission is required for the `github/codeql-action/upload-sarif` step. These permissions will be explicitly set to adhere to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
