### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,5 +1,9 @@
 name: Restyled
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/laniksj.github.io/security/code-scanning/3](https://github.com/LanikSJ/laniksj.github.io/security/code-scanning/3)

To fix the issue, we will add an explicit `permissions` block to the root of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, such as checking out code, running Restyled actions, and creating or closing pull requests, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating and managing pull requests.

The `permissions` block will be added at the root level of the workflow to apply to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
